### PR TITLE
Fix arrays on resize

### DIFF
--- a/Source/CFArray.c
+++ b/Source/CFArray.c
@@ -666,6 +666,8 @@ CFArrayReplaceValues (CFMutableArrayRef array, CFRange range,
       newSize = array->_count - range.length + newCount;
       CFArrayCheckCapacityAndGrow (array, newSize);
 
+      /* Re-calculate start on resize */
+      start = array->_contents + range.location;
       memmove (start + newCount, end,
                (array->_count - range.location +
                 range.length) * sizeof (void *));


### PR DESCRIPTION
Previously we were continuing to use our old memory location after a resize happens, leading to some invalid entries
